### PR TITLE
Conform to Docker best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM centos:7
 MAINTAINER Marek Goldmann <mgoldman@redhat.com>
 
-# Install packages necessary to run EAP
-RUN yum update -y && yum -y install xmlstarlet saxon augeas bsdtar unzip && yum clean all
-
-# Create a user and group used to launch processes
+# Install packages necessary to run EAP.
+# Then, create a user and group used to launch processes
 # The user ID 1000 is the default for the first "regular" user on Fedora/RHEL,
 # so there is a high chance that this ID will be equal to the current user
 # making it easier to use volumes (no permission issues)
-RUN groupadd -r jboss -g 1000 && useradd -u 1000 -r -g jboss -m -d /opt/jboss -s /sbin/nologin -c "JBoss user" jboss && \
-    chmod 755 /opt/jboss
+RUN yum update -y \
+    && yum -y install xmlstarlet saxon augeas bsdtar unzip \
+    && yum clean all \
+    && groupadd -r jboss -g 1000 \
+    && useradd -u 1000 -r -g jboss -m -d /opt/jboss -s /sbin/nologin -c "JBoss user" jboss 
+    && chmod 755 /opt/jboss
 
 # Set the working directory to jboss' user home directory
 WORKDIR /opt/jboss


### PR DESCRIPTION
Separated RUN commands onto different lines for readability. Reduced both run commands into one in order to reduce image layers.