### PR TITLE
Using patched Centos_7.4.1708

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:7.4.1708
 MAINTAINER Marek Goldmann <mgoldman@redhat.com>
 
 # Install packages necessary to run EAP


### PR DESCRIPTION
using latest, patched Centos 7.4 ... 

@goldmann Or not really needed, since we do get, with the implied `:latest` of the `7` repo already the "fixed" version ? 

https://github.com/CentOS/sig-cloud-instance-images/commit/16dab97b0ce72b1db7a2f9b02c76e452cb0a63cb

